### PR TITLE
changed param name for 'conceptScheme'

### DIFF
--- a/src/main/java/nl/knaw/huc/di/nde/recipe/OpenSKOS.java
+++ b/src/main/java/nl/knaw/huc/di/nde/recipe/OpenSKOS.java
@@ -34,7 +34,7 @@ public class OpenSKOS implements RecipeInterface {
         try {
             System.err.println("DBG: Lets cook some OpenSKOS!");
             String api = Saxon.xpath2string(config, "nde:api", null, OpenSKOS.NAMESPACES);
-            String cs  = Saxon.xpath2string(config, "nde:conceptScheme", null, OpenSKOS.NAMESPACES);
+            String cs  = Saxon.xpath2string(config, "nde:scheme", null, OpenSKOS.NAMESPACES);
             System.err.println("DBG: Ingredients:");
             System.err.println("DBG: - instance["+Saxon.xpath2string(config, "(nde:label)[1]", null, OpenSKOS.NAMESPACES)+"]");
             System.err.println("DBG: - api["+api+"]");


### PR DESCRIPTION
apparantly, the openskos parameter for filtering the searches to a specific skos:conceptScheme is different, that is 'scheme' instead of 'conceptScheme'. This neede to be changed, to prevent unwanted results to be sent back to the termennetwerk.

regards,
Willem