### PR TITLE
adding several conceptschemes and default to all

### DIFF
--- a/conf/termennetwerk.xml
+++ b/conf/termennetwerk.xml
@@ -17,7 +17,38 @@
     <nde:dataset id="gtaa" recipe="nl.knaw.huc.di.nde.recipe.OpenSKOS">
         <nde:label xml:lang="nl">Gemeenschappelijke Thesaurus Audiovisuele Archieven (B&amp;G)</nde:label>
         <nde:api>http://openskos.beeldengeluid.nl/api</nde:api>
+        <nde:tenant>beng</nde:tenant>
+        <nde:collection>gtaa</nde:collection>
+    </nde:dataset>
+    <nde:dataset id="gtaaonderwerpen" recipe="nl.knaw.huc.di.nde.recipe.OpenSKOS">
+        <nde:label xml:lang="nl">B&amp;G: GTAA Onderwerpen</nde:label>
+        <nde:api>http://openskos.beeldengeluid.nl/api</nde:api>
         <nde:conceptScheme>http://data.beeldengeluid.nl/gtaa/Onderwerpen</nde:conceptScheme>
+    </nde:dataset>
+    <nde:dataset id="gtaaplaatsen" recipe="nl.knaw.huc.di.nde.recipe.OpenSKOS">
+        <nde:label xml:lang="nl">B&amp;G: GTAA Plaatsen</nde:label>
+        <nde:api>http://openskos.beeldengeluid.nl/api</nde:api>
+        <nde:conceptScheme>http://data.beeldengeluid.nl/gtaa/GeografischeNamen</nde:conceptScheme>
+    </nde:dataset>
+    <nde:dataset id="gtaapersonen" recipe="nl.knaw.huc.di.nde.recipe.OpenSKOS">
+        <nde:label xml:lang="nl">B&amp;G: GTAA Personen</nde:label>
+        <nde:api>http://openskos.beeldengeluid.nl/api</nde:api>
+        <nde:conceptScheme>http://data.beeldengeluid.nl/gtaa/Persoonsnamen</nde:conceptScheme>
+    </nde:dataset>
+    <nde:dataset id="gtaanamen" recipe="nl.knaw.huc.di.nde.recipe.OpenSKOS">
+        <nde:label xml:lang="nl">B&amp;G: GTAA Namen</nde:label>
+        <nde:api>http://openskos.beeldengeluid.nl/api</nde:api>
+        <nde:conceptScheme>http://data.beeldengeluid.nl/gtaa/Namen</nde:conceptScheme>
+    </nde:dataset>
+    <nde:dataset id="gtaagenre" recipe="nl.knaw.huc.di.nde.recipe.OpenSKOS">
+        <nde:label xml:lang="nl">B&amp;G: GTAA Genre</nde:label>
+        <nde:api>http://openskos.beeldengeluid.nl/api</nde:api>
+        <nde:conceptScheme>http://data.beeldengeluid.nl/gtaa/Genre</nde:conceptScheme>
+    </nde:dataset>
+    <nde:dataset id="gtaaclassificatie" recipe="nl.knaw.huc.di.nde.recipe.OpenSKOS">
+        <nde:label xml:lang="nl">B&amp;G: GTAA Classificatie</nde:label>
+        <nde:api>http://openskos.beeldengeluid.nl/api</nde:api>
+        <nde:conceptScheme>http://data.beeldengeluid.nl/gtaa/Classificatie</nde:conceptScheme>
     </nde:dataset>
     <nde:dataset id="cht" recipe="nl.knaw.huc.di.nde.recipe.SparqlEndpoint">
         <nde:label xml:lang="nl">Cultuurhistorische Thesaurus (RCE)</nde:label>


### PR DESCRIPTION
some changes:
- several dataset sources are added to the config
- the openskos adapter now checks for existence of a conceptScheme parameter. If not configured it defaults a config using tenant and collection parameter. This was necessary to prevent defaulting to all sets/collections (which include some expired sets that never need to be used in the termennetwerk